### PR TITLE
fix: dont apply OS updates outside of the chain

### DIFF
--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -13,11 +13,6 @@ EXPOSE 8080
 ENTRYPOINT ["/usr/bin/entrypoint"]
 CMD ["/usr/bin/owncloud", "server"]
 
-RUN apt-get update -y && \
-  apt-get upgrade -y && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
-
 ADD owncloud.tar.bz2 /var/www/
 ADD user_ldap.tar.gz /var/www/owncloud/apps/
 ADD richdocuments.tar.gz /var/www/owncloud/apps/


### PR DESCRIPTION
OS updates should be applied to the Ubuntu base image only and transported up to the product images by the build chain.