### PR TITLE
ci: remove remaining arm32 refs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -79,9 +79,6 @@ def main(ctx):
             if config["arch"] == "arm64v8":
                 config["platform"] = "arm64"
 
-            if config["arch"] == "arm32v7":
-                config["platform"] = "arm"
-
             config["internal"] = "%s-%s-%s" % (ctx.build.commit, "${DRONE_BUILD_NUMBER}", config["tag"])
 
             for d in docker(config):

--- a/v20.04/manifest.tmpl
+++ b/v20.04/manifest.tmpl
@@ -15,8 +15,3 @@ manifests:
       architecture: arm64
       variant: v8
       os: linux
-  - image: owncloud/appliance:{{ if ne .Env.MANIFEST_VERSION "latest" }}{{ .Env.MANIFEST_VERSION }}-arm32v7{{ else }}arm32v7{{ end }}
-    platform:
-      architecture: arm
-      variant: v7
-      os: linux


### PR DESCRIPTION
As we don't have a Drone runner for arm32 anymore, remove it from the drone config.