### PR TITLE
chore: cleanup testfiles from apps and lib

### DIFF
--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -23,4 +23,6 @@ ADD overlay /
 WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
-  chmod g+w /var/www/owncloud
+  chmod g+w /var/www/owncloud && \
+  find /var/www/owncloud -iname tests -type d && \
+  find /var/www/owncloud -iname tests -type d -prune -exec rm -rf "{}" \;


### PR DESCRIPTION
```
#9 6.431 /var/www/owncloud/apps/oauth2/vendor/rowbot/url/tests
#9 6.431 /var/www/owncloud/apps/graphapi/vendor/microsoft/microsoft-graph/tests
#9 6.431 /var/www/owncloud/apps/openidconnect/vendor/jumbojett/openid-connect-php/tests
#9 6.431 /var/www/owncloud/lib/composer/pimple/pimple/src/Pimple/Tests
```